### PR TITLE
Update sil_tchad_qwerty.php

### DIFF
--- a/release/sil/sil_tchad_qwerty/source/help/sil_tchad_qwerty.php
+++ b/release/sil/sil_tchad_qwerty/source/help/sil_tchad_qwerty.php
@@ -1,10 +1,14 @@
-<?php
-  $pagename = "Tchad keyboard";
-  $pagetitle = "tchad qwerty keyboard";
+<?php /*
+  Name:        Tchad QWERTY Keyboard
+  Copyright:   2017-2024
+  Authors: Jeff Heath & roger Beramgoto Nadoumngar
+*/
+  $pagename = 'Tchad qwerty keyboard help';
+  $pagetitle = 'Tchad QWERTY keyboard Help';
   require_once('header.php');
 ?>
 <link rel="stylesheet" href="Td.css">
-<style type="text/css">
+<style type="text/css">               
 .keyboard {
   font-size: 20px;
   white-space: nowrap;
@@ -102,7 +106,6 @@
   color: #9400D3
 }
 </style>
-</head>
 
 <body data-device="Windows" data-section="keyboard">
 <div class="tab-folder">


### PR DESCRIPTION
the display of our help page in the keyman web page isn't exactly what we want and i've just changed a few things in the header if that helps. thanks

<?php **/***
 ** Name:        tchad QWERTY Unicode
  Copyright:   2017-202
  Authors: Jeff Heath & roger Beramgoto Nadoumngar
*/**
  $pagename = 'tchad **qwerty** keyboard **help**';
  $pagetitle = 'Tchad QWERTY keyboard **Help**';
  require_once('header.php');
?>
<link rel="stylesheet" href="Td.css">
<style type="text/css">    
**</head>**  

thanks 